### PR TITLE
Ensure SQL Server 2019

### DIFF
--- a/linux/setup/database-setup/docker-compose-sql-in-container.template.yml
+++ b/linux/setup/database-setup/docker-compose-sql-in-container.template.yml
@@ -2,7 +2,7 @@ version: "3.3"
 
 services:
   sql:
-    image: mcr.microsoft.com/mssql/server
+    image: mcr.microsoft.com/mssql/server:2019-latest
     container_name: intellix-sql-setup
     tty: true
     networks:

--- a/linux/setup/docker-compose-sql-in-container.template.yml
+++ b/linux/setup/docker-compose-sql-in-container.template.yml
@@ -39,7 +39,7 @@ services:
 
   sql:
     container_name: intellix-sql
-    image: mcr.microsoft.com/mssql/server
+    image: mcr.microsoft.com/mssql/server:2019-latest
     restart: unless-stopped
     tty: true
     networks:


### PR DESCRIPTION
Using an container image with just the _latest_ tag is not a good idea. It looks like the mcr.microsoft.com/mssql/server:latest suddenly points to mcr.microsoft.com/mssql/server:2017-latest. Therefore we use mcr.microsoft.com/mssql/server:2019-latest in our compose files.