### PR TITLE
Named networks and documentation update

### DIFF
--- a/doc/windows-setup-de.md
+++ b/doc/windows-setup-de.md
@@ -203,8 +203,8 @@ Laden Sie es herunter und folgen Sie den Anweisungen zum Einrichten.
 Es ist wichtig, dass Ihr SQL Server folgendermaßen konfiguriert ist:
 
 - TCP-Verbindungen an Port 1433.
-- UDP-Verbindungen an Port 1434.
-- Der _SQL Server Browser_-Dienst muss laufen.
+- UDP-Verbindungen an Port 1434, falls _named instances_ verwendet.
+- Der _SQL Server Browser_-Dienst muss laufen, falls _named instances_ verwendet.
 - Die SQL Server-Authentifizierung muss aktiviert sein.
   Die Container unterstützen keine integrierte Authentifizierung.
 - Für das Setup-Skript sollte ein SQL Server-Konto verfügbar sein.

--- a/doc/windows-setup-de.md
+++ b/doc/windows-setup-de.md
@@ -203,6 +203,8 @@ Laden Sie es herunter und folgen Sie den Anweisungen zum Einrichten.
 Es ist wichtig, dass Ihr SQL Server folgendermaßen konfiguriert ist:
 
 - TCP-Verbindungen an Port 1433.
+- UDP-Verbindungen an Port 1434.
+- Der _SQL Server Browser_-Dienst muss laufen.
 - Die SQL Server-Authentifizierung muss aktiviert sein.
   Die Container unterstützen keine integrierte Authentifizierung.
 - Für das Setup-Skript sollte ein SQL Server-Konto verfügbar sein.

--- a/doc/windows-setup-de.md
+++ b/doc/windows-setup-de.md
@@ -203,8 +203,8 @@ Laden Sie es herunter und folgen Sie den Anweisungen zum Einrichten.
 Es ist wichtig, dass Ihr SQL Server folgendermaßen konfiguriert ist:
 
 - TCP-Verbindungen an Port 1433.
-- UDP-Verbindungen an Port 1434, falls _named instances_ verwendet.
-- Der _SQL Server Browser_-Dienst muss laufen, falls _named instances_ verwendet.
+- UDP-Verbindungen an Port 1434, falls _named instances_ verwendet werden.
+- Der _SQL Server Browser_-Dienst muss laufen, falls _named instances_ verwendet werden.
 - Die SQL Server-Authentifizierung muss aktiviert sein.
   Die Container unterstützen keine integrierte Authentifizierung.
 - Für das Setup-Skript sollte ein SQL Server-Konto verfügbar sein.

--- a/doc/windows-setup.md
+++ b/doc/windows-setup.md
@@ -200,7 +200,9 @@ Download it and follow the setup instructions.
 
 It is important, that your SQL Server is configured like this:
 
-- TCP Connections on port 1433.
+- TCP connections on port 1433.
+- UDP connections on port 1434, in case you use named instances.
+- The _SQL Server Browser_ service must run, in case you use named instances.
 - SQL Server authentication must be enabled.
   The containers do not support integrated authentication.
 - A SQL Server account should be available for the setup script.

--- a/windows/setup/docker-compose-own-sql.template.yml
+++ b/windows/setup/docker-compose-own-sql.template.yml
@@ -32,3 +32,6 @@ services:
 
 networks:
   intellix:
+    external:
+      name: nat
+

--- a/windows/setup/docker-compose-sql-in-container.template.yml
+++ b/windows/setup/docker-compose-sql-in-container.template.yml
@@ -47,3 +47,5 @@ services:
 
 networks:
   intellix:
+    external:
+      name: nat


### PR DESCRIPTION
- Use named networks in Windows so that the containers do not crash after a restart.
- Update the documentation to enable the _SQL Server Browser_ when named instances are used.